### PR TITLE
quick sort eg, change from scan to each left

### DIFF
--- a/README.md
+++ b/README.md
@@ -1394,7 +1394,7 @@ This gives us confidence to wrestle down the last part, the recursion step:
 
                      /~x is 'not': boolean ¬x, non-0 turns 0, all 0 turn 1
 
- mask:~\cmp          /monadic 'not' scan:  returns cmp and negation of cmp
+ mask:~\:cmp         /monadic 'not' eachleft:  returns cmp and negation of cmp
  mask
 0 1 1 0
 1 0 0 1


### PR DESCRIPTION
In mi 2021.04.08 8 4 (c)shakti 2.0, eachleft returns cmp & negation of cmp -- scan does not.
```
 cmp:0 1 1 0

 mask:~\cmp
 mask
0 0 0 1

 mask:~\:cmp
 mask
0 1 1 0
1 0 0 1
```